### PR TITLE
buy_confirmation_purchase_function

### DIFF
--- a/app/views/items/buy_confirmation.html.haml
+++ b/app/views/items/buy_confirmation.html.haml
@@ -20,8 +20,8 @@
             .buy-main__content__final-price--right
               ¥#{@item.price.to_s(:delimited)}
           = submit_tag '購入する'
-          :plain
-          <script type="text/javascript" src="https://checkout.pay.jp" class="payjp-button" data-key="pk_test_f9835d81893c0b819997cdd6"></script>
+          -# :plain
+          -# <script type="text/javascript" src="https://checkout.pay.jp" class="payjp-button" data-key="pk_test_f9835d81893c0b819997cdd6"></script>
     %section.with_margin_top  
       .buy-main__content
         %h3 配送先
@@ -33,11 +33,11 @@
       .buy-main__content
         %h3 支払方法
         %p 
-          = "**** **** **** " + @credit_information.last4
+          = "**** **** **** " + @credit_information.last4 if @credit.present?
         %p 
-          - exp_month = @credit_information.exp_month.to_s
-          - exp_year = @credit_information.exp_year.to_s.slice(2,3)
-          = exp_month + " / " + exp_year
+          - exp_month = @credit_information.exp_month.to_s if @credit.present?
+          - exp_year = @credit_information.exp_year.to_s.slice(2,3) if @credit.present?
+          = exp_month + " / " + exp_year if @credit.present?
         %i.fab.fa-cc-visa.blue
         =link_to "変更する　＞"
   = render partial: "sell-footer"

--- a/app/views/items/item-detail.html.haml
+++ b/app/views/items/item-detail.html.haml
@@ -61,7 +61,10 @@
           %span.detail-main__item__price--number ¥#@price
           %span.detail-main__item__price--tax (税込) 
           %span.detail-main__item__price--charge 送料込み
-      = link_to('購入画面に進む', buy_confirmation_item_path(@item),class: 'detail-main__item__link-buy__btn detail-main__item__link-buy')
+      -if @credit.present?
+        = link_to('購入画面に進む', buy_confirmation_item_path(@item),class: 'detail-main__item__link-buy__btn detail-main__item__link-buy')
+      -else
+        =  link_to('購入画面に進む', '/users/card_registrations',class: 'detail-main__item__link-buy__btn detail-main__item__link-buy')
       -# .detail-main__item__link-buy
       .detail-main__item__description
         %p #{@item.description}


### PR DESCRIPTION
# What
購入機能実装
３パターン
①ユーザーログインしていない→ログイン画面へ
②ログインしているが、カード情報がない→カード登録画面へ
③ログインしており、カード情報を登録している→購入するボタンで、自動的に登録しているカードで購入される。

# Why
カードを手入力しての商品購入はできていたが、ルーティングとして、色々矛盾があったので調整。